### PR TITLE
Support the tcc compiler

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ To start TermiC:
 ```bash
 termic # For C shell
 termic++ # For C++ shell
+termic tcc # For C shell using the tcc compiler
 ```
 To remove TermiC system wide:
 ```bash

--- a/TermiC.sh
+++ b/TermiC.sh
@@ -15,6 +15,7 @@ lang="c"
 extension="c"
 compiler="gcc"
 addInclude=""
+[[ $1 == "tcc" ]] && compiler="tcc"
 [[ $1 == "cpp" ]] || [[ $0 =~ \+\+ ]] && lang="c++" && compiler="g++ -fpermissive" && extension="cpp" && addInclude="#include <iostream>\nusing namespace std;\n"
 echo TermiC 1.2.2V
 echo Language: $lang


### PR DESCRIPTION
Add support for the much faster [Tiny C Compiler](https://bellard.org/tcc/).

To use it, start TermiC with `termic tcc`.