### PR TITLE
Exit on EOF (Ctrl-d)

### DIFF
--- a/TermiC.sh
+++ b/TermiC.sh
@@ -32,7 +32,7 @@ echo -e  $initSource > $sourceFile
 
 while true;do
 	[[ $inlineCounter -gt 0 ]] && promptPS1="   " || promptPS1=">> "
-	read -rep "$promptPS1"$(echo $(yes ... | head -n $inlineCounter) | sed 's/ //g') prompt
+	read -rep "$promptPS1"$(echo $(yes ... | head -n $inlineCounter) | sed 's/ //g') prompt || break
 	[[ $prompt == "" ]] && continue
 	[[ $prompt == "exit" ]] && break
 	[[ $prompt == "clear" ]] && :> $sourceFile && :> $sourceFile.tmp && :> $binaryFile && fullPrompt="" && inlineCounter=0 && echo -e  $initSource > $sourceFile && continue


### PR DESCRIPTION
### Exit on EOF (Ctrl-d)

The exit status of `read` is `1` in this case. Thus, `|| break` after the `read` builtin breaks out of the `while` loop.

Closes #4.