### PR TITLE
Add command history

### DIFF
--- a/TermiC.sh
+++ b/TermiC.sh
@@ -24,6 +24,10 @@ oldPWD=`pwd`
 cd /tmp
 sourceFile=`mktemp termic-XXXXXXXX.$extension`
 binaryFile=`basename $sourceFile .$extension`
+cacheDir="${XDG_CACHE_HOME:-$HOME/.cache}/termic"
+[[ -d $cacheDir ]] || mkdir -p "$cacheDir"
+historyFile="$cacheDir/${extension}_history"
+history -r "$historyFile"
 fullPrompt=""
 inlineCounter=0
 promptPS1=">> "
@@ -34,6 +38,7 @@ while true;do
 	[[ $inlineCounter -gt 0 ]] && promptPS1="   " || promptPS1=">> "
 	read -rep "$promptPS1"$(echo $(yes ... | head -n $inlineCounter) | sed 's/ //g') prompt
 	[[ $prompt == "" ]] && continue
+	history -s "$prompt"
 	[[ $prompt == "exit" ]] && break
 	[[ $prompt == "clear" ]] && :> $sourceFile && :> $sourceFile.tmp && :> $binaryFile && fullPrompt="" && inlineCounter=0 && echo -e  $initSource > $sourceFile && continue
 	[[ $prompt == "abort" ]] && fullPrompt="" && inlineCounter=0 && continue
@@ -91,5 +96,6 @@ while true;do
 	fi
 done
 
+history -a "$historyFile"
 rm $sourceFile* &> /dev/null
 rm $binaryFile &> /dev/null


### PR DESCRIPTION
Save command history for C and C++ in `${XDG_CACHE_HOME}/termic/c_history` and `cpp_history`. When `$XDG_CACHE_HOME` is not set, `~/.cache` will be used instead.

History can be browsed with the up/down keys or Ctrl+p/n.