### PR TITLE
Disable filename completion on tab

### DIFF
--- a/TermiC.sh
+++ b/TermiC.sh
@@ -29,6 +29,8 @@ cacheDir="${XDG_CACHE_HOME:-$HOME/.cache}/termic"
 [[ -d $cacheDir ]] || mkdir -p "$cacheDir"
 historyFile="$cacheDir/${extension}_history"
 history -r "$historyFile"
+# disable filename completion on tab
+bind -r "\C-i" 2> /dev/null
 fullPrompt=""
 inlineCounter=0
 promptPS1=">> "


### PR DESCRIPTION
Pasting a tab-indented function definition into TermiC lets it print all files in `/tmp/`. The reason is that "tab" is (usually) bound to `menu-complete` (in bash) and this function is called when readline sees a tab, no matter if the tab key is pressed or tab characters are part of some pasted text.

I suppose that tab completion is more often triggered unintentionally than it is used on purpose while entering C/C++ code. This is why I propose to disable it.