### PR TITLE
Handle 'showtmp' failure gracefully

### DIFF
--- a/TermiC.sh
+++ b/TermiC.sh
@@ -45,7 +45,7 @@ while true;do
 	[[ $prompt == "clear" ]] && :> $sourceFile && :> $sourceFile.tmp && :> $binaryFile && fullPrompt="" && inlineCounter=0 && echo -e  $initSource > $sourceFile && continue
 	[[ $prompt == "abort" ]] && fullPrompt="" && inlineCounter=0 && continue
 	[[ $prompt == "show" ]] && cat $sourceFile && continue
-	[[ $prompt == "showtmp" ]] && cat $sourceFile.tmp && continue
+	[[ $prompt == "showtmp" ]] && { [[ -f $sourceFile.tmp ]] && cat $sourceFile.tmp || echo "No .tmp file!"; continue; }
 	[[ $prompt == "save" ]] && cp $sourceFile $oldPWD && echo "}" >> $oldPWD/$sourceFile && echo "Source file saved to $oldPWD/$sourceFile" && continue
 	[[ $prompt == "savebin" ]] && cp $binaryFile $oldPWD && echo "Binary file saved to $oldPWD/$binaryFile" && continue
 	[[ $prompt == "help" ]] && echo -e "Designed by Yusuf Kağan Hanoğlu\nLicensed by GPLv3\


### PR DESCRIPTION
As long as you enter correct code in TermiC, there is no `/tmp/termic-xxxx.c.tmp` file. When you then accidentally call `showtmp` (instead of `show`), `cat` fails to find this `tmp` file which results in `continue` being skipped and the `showtmp` is pasted in the C main function.

**This pull request**: Check if the tmp file exists before printing it and print a message otherwise and `continue` in either case.