### PR TITLE
Don't duplicate trailing semicolons

### DIFF
--- a/TermiC.sh
+++ b/TermiC.sh
@@ -77,6 +77,7 @@ while true;do
 		[[ $fullPrompt =~ ^.?[[:alnum:]\*:]*[[:blank:]]*(namespace|class|struct)[[:blank:]]*[[:alnum:]\*:]*[[:blank:]]*.*\{ ]] && addOutsideMain=true
 		# If if/else if/else/switch/while/do while/for/try/catch
 		[[ $fullPrompt =~ ^.?[[:blank:]]*(if|else if|else|switch|while|do|for|try|catch).*\{ ]] && addOutsideMain=false && addToBegining=false && addSemicolon=""
+		[[ $fullPrompt == *";" ]] && addSemicolon=""
 		if $addToBegining;then
 			echo "$fullPrompt"$addSemicolon > $sourceFile.tmp
 			echo "`cat $sourceFile`" >> $sourceFile.tmp


### PR DESCRIPTION
TermiC adds a trailing semicolon where it might be missing. This results in double semicolons when the entered/pasted line already ends in a semicolon.

Change in this pull request: Don't add semicolons to lines that already end with a semicolon.