### PR TITLE
fix: Save the code if there's an output too.

### DIFF
--- a/TermiC.sh
+++ b/TermiC.sh
@@ -111,7 +111,8 @@ while true;do
 
 		if $compiledSuccessfully;then
 			retval=`./$binaryFile 2>&1`
-			[[ $retval == "" ]] && mv $sourceFile.tmp $sourceFile || echo "$retval"
+			[[ $retval == "" ]] || echo "$retval"
+			mv $sourceFile.tmp $sourceFile
 		fi
 	fi
 done


### PR DESCRIPTION
Hi Yusuf, it's Alper. Good to see you here! It's been a while since you told me about this code, and I'm glad to have the opportunity to get my hands on it finally.

This commit addresses the issue where the "show" command in the TermiC script was not displaying the entire code. The issue was that the script would only "save" the code for "show" to display if there was no output. Changed it so that it'll save if there's an output too.

This PR fixes #14.