### PR TITLE
Account for dangerous mktemp fail

### DIFF
--- a/TermiC.sh
+++ b/TermiC.sh
@@ -46,6 +46,7 @@ echo Type \'help\' for additional information
 oldPWD=`pwd`
 cd /tmp
 sourceFile=`mktemp termic-XXXXXXXX.$extension`
+[[ -z "$sourceFile" ]] && exit 1
 binaryFile=`basename $sourceFile .$extension`
 cacheDir="${XDG_CACHE_HOME:-$HOME/.cache}/termic"
 [[ -d $cacheDir ]] || mkdir -p "$cacheDir"


### PR DESCRIPTION
If the `mktemp` fails `$sourceFile` will become empty, which is problematic because of this command: `rm $sourceFile* &> /dev/null`, at the end.
It would delete other temporary files, or at worst case, if the `cd` fails too, it would corrupt the user's working directory.